### PR TITLE
Change "oldstable" to "oldoldstable" for lidb4.8*

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -77,7 +77,7 @@ for Debian 7 (Wheezy) and later:
  Add the following line to /etc/apt/sources.list,
  replacing [mirror] with any official debian mirror.
 
-	deb http://[mirror]/debian/ oldstable main
+	deb http://[mirror]/debian/ oldoldstable main
 
 To enable the change run
 


### PR DESCRIPTION
https://packages.debian.org/search?searchon=names&exact=1&suite=all&section=all&keywords=libdb4.8
Berkeley DB 4.8 is part of squeeze, which is now "oldoldstable."
